### PR TITLE
メモ一覧の表示を修正

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -29,7 +29,7 @@ class HomeController extends Controller
         $memos = Memo::select('memos.*')
                 ->where('user_id', '=', Auth::id())
                 ->whereNull('deleted_at')
-                ->orderBy('id', 'DESC')
+                ->orderBy('updated_at', 'DESC')
                 ->get();
 
         // 取得したメモ一覧をビューに返す
@@ -55,7 +55,7 @@ class HomeController extends Controller
         $memos = Memo::select('memos.*')
         ->where('user_id', '=', Auth::id())
         ->whereNull('deleted_at')
-        ->orderBy('id', 'DESC')
+        ->orderBy('updated_at', 'DESC')
         ->get();
 
         // 編集するメモを取得


### PR DESCRIPTION
## 内容
更新時間が新しい順にメモ一覧を表示するように変更

## なぜ実装、または変更を行ったか
新しい順に表示することで最新のメモがユーザーの目につきやすくする為

## 動作確認（キャプチャ）
https://user-images.githubusercontent.com/50309689/153623746-dcf0b34d-034a-4df6-9829-1e45e66f244d.mov


## その他(懸念点など)
特になし